### PR TITLE
Removed flat value from task name

### DIFF
--- a/roles/toolchain-setup/tasks/main.yml
+++ b/roles/toolchain-setup/tasks/main.yml
@@ -79,7 +79,7 @@
   - docker
 
 # Add Media mount to FStab
-- name: Mount NAS Media folder to /mnt/Media
+- name: Mount NAS Media folder to local filesystem
   mount:
     state: mounted
     path: "{{ media_root_path }}" 


### PR DESCRIPTION
Addressing #17 

Rather than use a parameter int he task name, simply describe it instead

From "Mount NAS Media folder to /mnt/Media"
To "Mount NAS Media folder to local filesystem"